### PR TITLE
fix(escaping): Use template literals instead of ' quotes to encapsula…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+.DS_Store
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/src/lib/generators/code-snippet-generators.ts
+++ b/src/lib/generators/code-snippet-generators.ts
@@ -30,7 +30,7 @@ export const generateSvgConstant = (
 ): string => {
   return `export const ${variableName}: ${interfaceName} = {
                 name: '${filenameWithoutEnding}',
-                data: '${data}'
+                data: \`${data}\`
             };`;
 };
 
@@ -46,7 +46,7 @@ export const generateSvgConstantWithImport = (
   
     export const ${variableName}: ${interfaceName} = {
                 name: '${filenameWithoutEnding}',
-                data: '${data}'
+                data: \`${data}\`
             };`;
 };
 
@@ -58,7 +58,7 @@ export const generateSvgStandaloneFile = (
 ): string => {
   return `export const ${variableName}: ${interfaceName} = {
                 name: '${filenameWithoutEnding}',
-                data: '${data}'
+                data: \`${data}\`
             };`;
 };
 


### PR DESCRIPTION
…te svgs, as the quote character can occur in svgs.

Fixes #30 .