### PR TITLE
feat(type-name): add new delimiter UPPER

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ accepts an object with the filename as key and the svg data as key.
 
 #### Available options:
 
-| --version       | type                    | default                                  | description                                                                  |
-| --------------- | ----------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| fileName        | stirng                  | my-icons                                 | file name of the generated file                                              |
-| delimiter       | CAMEL, KEBAB, SNAKE     | CAMEL                                    | delimiter which is used to generate the types and name properties            |
-| svgoConfig      | string or config object | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object |
-| srcFiles        | string                  | "/\*.svg"                                | input files matching the given filename pattern                              |
-| outputDirectory | string                  | "./dist"                                 | name of the output directory                                                 |
-| objectName      | string                  | default - export                         | name of the exported const - if nothing is set - default export will be used |
+| --version       | type                       | default                                  | description                                                                  |
+| --------------- | -------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| fileName        | stirng                     | my-icons                                 | file name of the generated file                                              |
+| delimiter       | CAMEL, KEBAB, SNAKE, UPPER | CAMEL                                    | delimiter which is used to generate the types and name properties            |
+| svgoConfig      | string or config object    | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object |
+| srcFiles        | string                     | "/\*.svg"                                | input files matching the given filename pattern                              |
+| outputDirectory | string                     | "./dist"                                 | name of the output directory                                                 |
+| objectName      | string                     | default - export                         | name of the exported const - if nothing is set - default export will be used |
 
 #### Example usage
 
@@ -218,18 +218,18 @@ Only the icons included in the consuming SPA also end up in the final bundle of 
 
 #### Available options:
 
-| --version          | type                    | default                                  | description                                                                  |
-| ------------------ | ----------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| typeName           | string                  | myIcons                                  | name of the generated type                                                   |
-| generateType       | boolean                 | false                                    | prevent generating enumeration type                                          |
-| generateTypeObject | boolean                 | false                                    | generate type object                                                         |
-| prefix             | string                  | myIcon                                   | prefix for the generated svg constants                                       |
-| interfaceName      | string                  | MyIcon                                   | name for the generated interface                                             |
-| fileName           | stirng                  | my-icons                                 | file name of the generated file                                              |
-| delimiter          | CAMEL, KEBAB, SNAKE     | SNAKE                                    | delimiter which is used to generate the types and name properties            |
-| svgoConfig         | string or config object | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object |
-| srcFiles           | string                  | "/\*.svg"                                | input files matching the given filename pattern                              |
-| outputDirectory    | string                  | "./dist"                                 | name of the output directory                                                 |
+| --version          | type                       | default                                  | description                                                                  |
+| ------------------ | -------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| typeName           | string                     | myIcons                                  | name of the generated type                                                   |
+| generateType       | boolean                    | false                                    | prevent generating enumeration type                                          |
+| generateTypeObject | boolean                    | false                                    | generate type object                                                         |
+| prefix             | string                     | myIcon                                   | prefix for the generated svg constants                                       |
+| interfaceName      | string                     | MyIcon                                   | name for the generated interface                                             |
+| fileName           | stirng                     | my-icons                                 | file name of the generated file                                              |
+| delimiter          | CAMEL, KEBAB, SNAKE, UPPER | SNAKE                                    | delimiter which is used to generate the types and name properties            |
+| svgoConfig         | string or config object    | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object |
+| srcFiles           | string                     | "/\*.svg"                                | input files matching the given filename pattern                              |
+| outputDirectory    | string                     | "./dist"                                 | name of the output directory                                                 |
 
 #### Example usage
 
@@ -291,23 +291,23 @@ end up there.
 
 #### Available options:
 
-| --version                 | type                    | default                                  | description                                                                                                                                                                     |
-| ------------------------- | ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| barrelFileName            | string                  | index                                    | name of the generated type                                                                                                                                                      |
-| typeName                  | string                  | myIcons                                  | name of the generated type                                                                                                                                                      |
-| generateType              | boolean                 | false                                    | prevent generating enumeration type                                                                                                                                             |
-| generateTypeObject        | boolean                 | false                                    | generate type object                                                                                                                                                            |
-| exportCompleteIconSet     | boolean                 | false                                    | Specifies if the complete icon set should be exported or not (can be very handy for showcases)                                                                                  |
-| prefix                    | string                  | myIcon                                   | prefix for the generated svg constants                                                                                                                                          |
-| interfaceName             | string                  | MyIcon                                   | name for the generated interface                                                                                                                                                |
-| fileName                  | stirng                  | my-icons                                 | file name of the generated file                                                                                                                                                 |
-| delimiter                 | CAMEL, KEBAB, SNAKE     | SNAKE                                    | delimiter which is used to generate the types and name properties                                                                                                               |
-| srcFiles                  | string                  | "/\*.svg"                                | input files matching the given filename pattern                                                                                                                                 |
-| svgoConfig                | string or config object | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object                                                                                                    |
-| outputDirectory           | string                  | "./dist"                                 | name of the output directory                                                                                                                                                    |
-| additionalModelOutputPath | string                  | null                                     | if a path is specified we will generate an additional file containing interface and type to this path - can be useful to improve type safety                                    |
-| iconsFolderName           | string                  | "build"                                  | name of the folder we will build the TypeScript files to                                                                                                                        |
-| compileSources            | boolean                 | false                                    | If set to false, we generate a TypeScript file for each SVG. If set to true we will allready compile those TypeScript files and generate JavaScript files and declaration files |
+| --version                 | type                       | default                                  | description                                                                                                                                                                     |
+| ------------------------- | -------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| barrelFileName            | string                     | index                                    | name of the generated type                                                                                                                                                      |
+| typeName                  | string                     | myIcons                                  | name of the generated type                                                                                                                                                      |
+| generateType              | boolean                    | false                                    | prevent generating enumeration type                                                                                                                                             |
+| generateTypeObject        | boolean                    | false                                    | generate type object                                                                                                                                                            |
+| exportCompleteIconSet     | boolean                    | false                                    | Specifies if the complete icon set should be exported or not (can be very handy for showcases)                                                                                  |
+| prefix                    | string                     | myIcon                                   | prefix for the generated svg constants                                                                                                                                          |
+| interfaceName             | string                     | MyIcon                                   | name for the generated interface                                                                                                                                                |
+| fileName                  | stirng                     | my-icons                                 | file name of the generated file                                                                                                                                                 |
+| delimiter                 | CAMEL, KEBAB, SNAKE, UPPER | SNAKE                                    | delimiter which is used to generate the types and name properties                                                                                                               |
+| srcFiles                  | string                     | "/\*.svg"                                | input files matching the given filename pattern                                                                                                                                 |
+| svgoConfig                | string or config object    | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object                                                                                                    |
+| outputDirectory           | string                     | "./dist"                                 | name of the output directory                                                                                                                                                    |
+| additionalModelOutputPath | string                     | null                                     | if a path is specified we will generate an additional file containing interface and type to this path - can be useful to improve type safety                                    |
+| iconsFolderName           | string                     | "build"                                  | name of the folder we will build the TypeScript files to                                                                                                                        |
+| compileSources            | boolean                    | false                                    | If set to false, we generate a TypeScript file for each SVG. If set to true we will allready compile those TypeScript files and generate JavaScript files and declaration files |
 
 #### Example usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-ts",
-  "version": "5.2.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4179,12 +4179,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "git-cz": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/git-cz/-/git-cz-4.7.1.tgz",
-      "integrity": "sha512-Emb/Xz/LcL3SGxA/PD6RUrhUT6m2v0O9nWTjwCBAoE2UXxj9HkJcfphL3RkePtiTNFkVZMk0q5EUfHnO7HAfiw==",
-      "dev": true
-    },
     "git-log-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
@@ -6651,6 +6645,11 @@
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
+    },
+    "lodash.toupper": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.toupper/-/lodash.toupper-4.1.2.tgz",
+      "integrity": "sha1-s/3z2DuIDIdQ1Qm2QHU4XH7KL8M="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start-object:kebab": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s 'inputfiles-hyphen/*.svg' -d KEBAB",
     "start-object:snake": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s 'inputfiles-hyphen/*.svg' -d SNAKE",
     "start-object:camel": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s 'inputfiles-hyphen/*.svg' -d CAMEL",
+    "start-object:upper": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s 'inputfiles-hyphen/*.svg' -d UPPER",
     "start-object:multiple-source": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s './inputfiles/*.svg' -s 'inputfiles-hyphen/*.svg'",
     "start-object:custom": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s './inputfiles/*.svg' -o ./dist --objectName awesomeIcons -f icons",
     "start-object:export-const": "ts-node ./src/bin/svg-to-ts.ts --conversionType object -s './inputfiles/*.svg' -o ./dist --objectName myIcons",
@@ -28,6 +29,7 @@
     "start-constants:kebab": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -d KEBAB",
     "start-constants:snake": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -d SNAKE",
     "start-constants:camel": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -d CAMEL",
+    "start-constants:upper": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -d UPPER",
     "start-constants:multiple-source": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -s 'inputfiles-hyphen/*.svg'",
     "start-constants:custom": "ts-node ./src/bin/svg-to-ts.ts --conversionType constants -s './inputfiles/*.svg' -o ./dist -t sampleIcon -i SampleIcon -p sampleIcon -f icons",
     "start-files": "ts-node ./src/bin/svg-to-ts.ts --conversionType files  -s './inputfiles/*.svg'",
@@ -38,12 +40,14 @@
     "start-files:kebab": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -d KEBAB",
     "start-files:snake": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -d SNAKE",
     "start-files:camel": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -d CAMEL",
+    "start-files:upper": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -d UPPER",
     "start-files:multiple-source": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -s 'inputfiles-hyphen/*.svg'",
     "start-files:customModel": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfilesRegex/**/*.svg' --modelFileName test-model -t sampleIcon -i SampleIcon",
     "start-files:custom": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -o ./dist -t sampleIcon -i SampleIcon -p sampleIcon -f icons",
     "start-files:custom-complete-icon-set": "ts-node ./src/bin/svg-to-ts.ts --conversionType files -s './inputfiles/*.svg' -o ./dist -t sampleIcon -i SampleIcon -p sampleIcon -f icons --exportCompleteIconSet true",
     "start:help": "ts-node ./src/bin/svg-to-ts.ts -h",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "test": "jest --config=./jest.config.js --coverage"
   },
   "repository": {
     "type": "git",
@@ -78,6 +82,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "lodash.snakecase": "^4.1.1",
+    "lodash.toupper": "^4.1.2",
     "svgo": "^1.3.2",
     "typescript": "^3.7.2"
   },

--- a/src/lib/generators/code-snippet-generators.spec.ts
+++ b/src/lib/generators/code-snippet-generators.spec.ts
@@ -1,8 +1,10 @@
 import {
+  Delimiter,
   generateInterfaceDefinition,
   generateNamedImportStatement,
   generateSvgConstant,
   generateTypeDefinition,
+  generateTypeName,
   generateVariableName
 } from './code-snippet-generators';
 import { ConstantsConversionOptions } from '../options/conversion-options';
@@ -93,6 +95,28 @@ describe('Generators', () => {
                 data: \`${data}\`
             };`;
     expect(generateSvgConstant(variableName, interfaceName, filenameWithoutEnding, data)).toEqual(expectedSVGConstant);
+  });
+
+  describe('generateTypeName', () => {
+    it('should return the correct type name with delimiter SNAKE', () => {
+      const fileName = 'chevron-top';
+      expect(generateTypeName(fileName, Delimiter.SNAKE)).toEqual('chevron_top');
+    });
+
+    it('should return the correct type name with delimiter CAMEL', () => {
+      const fileName = 'chevron-top';
+      expect(generateTypeName(fileName, Delimiter.CAMEL)).toEqual('chevronTop');
+    });
+
+    it('should return the correct type name with delimiter KEBAB', () => {
+      const fileName = 'chevron_top';
+      expect(generateTypeName(fileName, Delimiter.KEBAB)).toEqual('chevron-top');
+    });
+
+    it('should return the correct type name with delimiter UPPER', () => {
+      const fileName = 'chevron-top';
+      expect(generateTypeName(fileName, Delimiter.UPPER)).toEqual('CHEVRON_TOP');
+    });
   });
 
   describe('generateVariableName', () => {

--- a/src/lib/generators/code-snippet-generators.ts
+++ b/src/lib/generators/code-snippet-generators.ts
@@ -1,13 +1,15 @@
 import snakeCase from 'lodash.snakecase';
 import camelCase from 'lodash.camelcase';
-import kebapCase from 'lodash.kebabcase';
+import kebabCase from 'lodash.kebabcase';
+import toUpper from 'lodash.toupper';
 import { SvgDefinition } from '../converters/shared.converter';
 import { FileConversionOptions, ConstantsConversionOptions } from '../options/conversion-options';
 
 export enum Delimiter {
   CAMEL = 'CAMEL',
   KEBAB = 'KEBAB',
-  SNAKE = 'SNAKE'
+  SNAKE = 'SNAKE',
+  UPPER = 'UPPER'
 }
 
 export const generateInterfaceDefinition = (conversionOptions: FileConversionOptions | ConstantsConversionOptions) => {
@@ -91,7 +93,10 @@ export const generateTypeName = (filenameWithoutEnding, delimiter: Delimiter): s
     return `${camelCase(filenameWithoutEnding)}`;
   }
   if (delimiter === Delimiter.KEBAB) {
-    return `${kebapCase(filenameWithoutEnding)}`;
+    return `${kebabCase(filenameWithoutEnding)}`;
+  }
+  if (delimiter === Delimiter.UPPER) {
+    return `${toUpper(snakeCase(filenameWithoutEnding))}`;
   }
   return `${snakeCase(filenameWithoutEnding)}`;
 };

--- a/src/lib/helpers/complete-icon-set-helper.spec.ts
+++ b/src/lib/helpers/complete-icon-set-helper.spec.ts
@@ -9,9 +9,9 @@ describe('Complete Iconset-helper', () => {
       { variableName: 'baz', prefix: 'sampleIcon', filenameWithoutEnding: 'baz' }
     ] as any;
     const expectedContent = `
-    import {foo} from './foo.icon';
-    import {bar} from './bar.icon';
-    import {baz} from './baz.icon';
+    import {foo} from './sampleIcon-foo.icon';
+    import {bar} from './sampleIcon-bar.icon';
+    import {baz} from './sampleIcon-baz.icon';
             
     export const completeIconSet = [foo, bar, baz];`;
 


### PR DESCRIPTION
Hi!

It's my first PR here (cool library!), so please tell me if there's anything wrong.

**Motivation**
With this library can generate an enum to handle our icon names like this:

```
export const IconTruck: Icon = {
  name: 'chevron-top',
  data: `...`,
};
export const IconWorld: Icon = {
  name: 'world',
  data: `...`,
};
export type IconNames =
  | 'chevron-top'
  | 'world';
export const IconNames = {
  'chevron-top': 'chevron-top' as IconNames,
  world: 'world' as IconNames,
};
export interface Icon {
  name: IconNames;
  data: string;
}
```
In the case of use that motivates it, we are wrapping the use of this icon set in a component of React like this:
```
import classNames from 'classnames';
import React, { useMemo } from 'react';

import * as IconSet from './icons';

export const IconNames = IconSet.IconNames;
export type IconNames = IconSet.IconNames;

export enum IconSize {
    SIZE_SMALL = 'small',
    SIZE_REGULAR = 'regular',
    SIZE_LARGE = 'large',
}

export interface IIconProps {
    /** Name of the icon to be displayed */
    name: IconNames;
    /** Size of the icon */
    size?: IconSize;
}

export const Icon: React.SFC<IIconProps> = (props: IIconProps): JSX.Element => {
    const { name, size = IconSize.SIZE_REGULAR } = props;
    const className = classNames({
        [`icon icon--${name}`]: true,
        [`icon--${size}`]: size !== IconSize.SIZE_REGULAR,
    });

    const icon = useMemo((): IconSet.Icon => {
        return Object.values(IconSet)
            .find((icon: IconSet.Icon): boolean => icon.name === name)
    }, [name]);

    return (
        <img
            className={className}
            aria-hidden="true"
            src={`data:image/svg+xml;utf8,${encodeURIComponent(icon?.data)}`}
        />
    );
};
```
So this allow to use our Icon component in our app with the IconNames enum check like this:
```
storiesOf('Components/Icon', module)
    .add('basic', () => {
        return (
            <div className="sb__icons-container">
                <Icon name={IconNames['chevron-top']} />
                <Icon name={IconNames.world} size={IconSize.SIZE_SMALL} />
            </div>
        );
    })
```
But this is not the best way since the convention in these cases is to use it as upper with an underscore (lot of documentation about this can be found, I can provide also if you want).

So with this PR we added a new delimiter (optional) that allows to cover this use. The result applying it would be:
```
export const IconTruck: Icon = {
  name: 'CHEVRON_TOP',
  data: `...`,
};
export const IconWorld: Icon = {
  name: 'WORLD',
  data: `...`,
};
export type IconNames =
  | 'CHEVRON_TOP'
  | 'WORLD';
export const IconNames = {
  CHEVRON_TOP: 'CHEVRON_TOP' as IconNames,
  WORLD: 'WORLD' as IconNames,
};
export interface Icon {
  name: IconNames;
  data: string;
}

...

storiesOf('Components/Icon', module)
    .add('basic', () => {
        return (
            <div className="sb__icons-container">
                <Icon name={IconNames.CHEVRON_TOP} />
                <Icon name={IconNames.WORLD} size={IconSize.SIZE_SMALL} />
            </div>
        );
    })
```

**Other changes**
I was not able to launch the tests initially so I have added an option in the package to do it, also iI added tests cases to the all delimiters.

Any questions or comments please tell me