### PR TITLE
chore: 🤖 remove lodash dependency and replace with native JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-ts",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6645,11 +6645,6 @@
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
-    },
-    "lodash.toupper": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.toupper/-/lodash.toupper-4.1.2.tgz",
-      "integrity": "sha1-s/3z2DuIDIdQ1Qm2QHU4XH7KL8M="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "lodash.snakecase": "^4.1.1",
-    "lodash.toupper": "^4.1.2",
     "svgo": "^1.3.2",
     "typescript": "^3.7.2"
   },

--- a/src/lib/generators/code-snippet-generators.ts
+++ b/src/lib/generators/code-snippet-generators.ts
@@ -96,7 +96,7 @@ export const generateTypeName = (filenameWithoutEnding, delimiter: Delimiter): s
     return `${kebabCase(filenameWithoutEnding)}`;
   }
   if (delimiter === Delimiter.UPPER) {
-    return `${toUpper(snakeCase(filenameWithoutEnding))}`;
+    return `${snakeCase(filenameWithoutEnding).toUpperCase()}`;
   }
   return `${snakeCase(filenameWithoutEnding)}`;
 };


### PR DESCRIPTION
@jvelay I think we actually don't need to include the lodash.toUpper package since the same can be achieved with a native `toUpperCase`.