### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,24 +130,22 @@ Once you run `svg-to-ts` those configurations will be picked up.
 
 ```json
 {
-  "svg-to-ts": {
-    "conversionType": "constants",
-    "srcFiles": ["./projects/dinosaur-icons/icons/**/*.svg"],
-    "outputDirectory": "./projects/dinosaur-icons/icons",
-    "interfaceName": "DinosaurIcon",
-    "typeName": "dinosaurIcon",
-    "prefix": "dinosaurIcon",
-    "modelFileName": "dinosaur-icon.model",
-    "svgoConfig": {
-      "plugins": [
-        {
-          "cleanupAttrs": true
-        }
-      ]
-    },
-    "additionalModelFile": "./projects/dinosaur-icons/src/lib",
-    "compileSources": true
-  }
+  "conversionType": "constants",
+  "srcFiles": ["./projects/dinosaur-icons/icons/**/*.svg"],
+  "outputDirectory": "./projects/dinosaur-icons/icons",
+  "interfaceName": "DinosaurIcon",
+  "typeName": "dinosaurIcon",
+  "prefix": "dinosaurIcon",
+  "modelFileName": "dinosaur-icon.model",
+  "svgoConfig": {
+    "plugins": [
+      {
+        "cleanupAttrs": true
+      }
+    ]
+  },
+  "additionalModelFile": "./projects/dinosaur-icons/src/lib",
+  "compileSources": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Once you run `svg-to-ts` those configurations will be picked up. The config obje
         }
       ]
     },
-    "modelFileName": "dinosaur-icon.model",
+    "fileName": "dinosaur-icon.model",
     "additionalModelFile": "./projects/dinosaur-icons/src/lib",
     "compileSources": true
   }
@@ -136,7 +136,7 @@ Once you run `svg-to-ts` those configurations will be picked up.
   "interfaceName": "DinosaurIcon",
   "typeName": "dinosaurIcon",
   "prefix": "dinosaurIcon",
-  "modelFileName": "dinosaur-icon.model",
+  "fileName": "dinosaur-icon.model",
   "svgoConfig": {
     "plugins": [
       {


### PR DESCRIPTION
fix: remove `svg-to-ts` attribute from `.svg-to-tsrc` example. Got an error if this attribute is present.
![image](https://user-images.githubusercontent.com/9607309/96369367-c0d6db80-1159-11eb-982a-573f7a7fd490.png)

fix: replace `modelFileName` by `fileName` in example

I'm not sure if `additionalModelFile` is still use. Can you check this ?