### PR TITLE
fix: error for lots of icons in completeIconSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 ![npms.io (final)](https://img.shields.io/npms-io/maintenance-score/svg-to-ts) ![GitHub Workflow](https://img.shields.io/github/workflow/status/kreuzerk/svg-to-ts/release) ![GitHub](https://img.shields.io/github/license/kreuzerk/svg-to-ts) ![npm](https://img.shields.io/npm/v/svg-to-ts)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -252,7 +254,7 @@ accepts an object with the filename as key and the svg data as key.
 | outputDirectory | string                     | "./dist"                                 | name of the output directory                                                                 |
 | objectName      | string                     | default - export                         | name of the exported const - if nothing is set - default export will be used                 |
 | verbose         | boolean                    | false                                    | defines if the log should contain additional information. Can be useful for debugging        |
-| generateType    | boolean                    | true                                     | defines if it's needed to generate type                                                      |
+| generateType    | boolean                    | true                                     | defines if a type should be generated                                                        |
 | typeName        | string                     | MyIconType                               | name of the type to be used when `generateType` is set to `true`                             |
 | namePrefix      | string                     |                                          | prefix to be used for the name property included in the generated constant                   |
 
@@ -295,9 +297,9 @@ Only the icons included in the consuming SPA also end up in the final bundle of 
 
 | --version             | type                       | default                                  | description                                                                           |
 | --------------------- | -------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
-| typeName              | string                     | myIcons                                  | name of the generated type                                                            |
 | tsx                   | boolean                    | false                                    | Generate TSX file which can be used as React components out of the box                |
-| generateType          | boolean                    | false                                    | prevent generating enumeration type                                                   |
+| generateType          | boolean                    | false                                    | defines if a type should be generated                                                 |
+| typeName              | string                     | myIcons                                  | name of the type to be used when `generateType` is set to `true`                      |
 | generateTypeObject    | boolean                    | false                                    | generate type object                                                                  |
 | generateEnum          | boolean                    | false                                    | generate enum object                                                                  |
 | prefix                | string                     | myIcon                                   | prefix for the generated svg constants                                                |
@@ -389,8 +391,8 @@ end up there.
 | ------------------------- | -------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | barrelFileName            | string                     | index                                    | name of the generated type                                                                                                                                                      |
 | tsx                       | boolean                    | false                                    | Generate TSX file which can be used as React components out of the box                                                                                                          |
-| typeName                  | string                     | myIcons                                  | name of the generated type                                                                                                                                                      |
-| generateType              | boolean                    | false                                    | prevent generating enumeration type                                                                                                                                             |
+| generateType              | boolean                    | false                                    | defines if a type should be generated                                                                                                                                           |
+| typeName                  | string                     | myIcons                                  | name of the type to be used when `generateType` is set to `true`                                                                                                                |
 | generateTypeObject        | boolean                    | false                                    | generate type object                                                                                                                                                            |
 | generateEnum              | boolean                    | false                                    | generate enum object                                                                                                                                                            |
 | exportCompleteIconSet     | boolean                    | false                                    | Specifies if the complete icon set should be exported or not (can be very handy for showcases)                                                                                  |

--- a/src/lib/converters/files.converter.ts
+++ b/src/lib/converters/files.converter.ts
@@ -36,7 +36,9 @@ async function generateTSXFiles(conversionOptions: FilesConversionOptions) {
     iconsFolderName,
     exportCompleteIconSet,
     completeIconSetName,
-    barrelFileName
+    barrelFileName,
+    interfaceName,
+    generateType
   } = conversionOptions;
 
   const svgDefinitions = await callAndMonitorAsync<SvgDefinition[]>(
@@ -51,7 +53,14 @@ async function generateTSXFiles(conversionOptions: FilesConversionOptions) {
 
   if (exportCompleteIconSet) {
     await callAndMonitorAsync<void>(
-      generateCompleteIconSet.bind({}, svgDefinitions, outputDirectory, iconsFolderName, completeIconSetName),
+      generateCompleteIconSet.bind(
+        {},
+        svgDefinitions,
+        outputDirectory,
+        iconsFolderName,
+        completeIconSetName,
+        generateType && interfaceName
+      ),
       'Export complete icon set'
     );
     generatedFileNames.push(completeIconSetName);
@@ -80,7 +89,8 @@ async function generateTSFiles(conversionOptions: FilesConversionOptions) {
     exportCompleteIconSet,
     completeIconSetName,
     compilationOutput,
-    barrelFileName
+    barrelFileName,
+    generateType
   } = conversionOptions;
   await callAndMonitorAsync<void>(
     deleteFolder.bind({}, `${outputDirectory}/${iconsFolderName}`),
@@ -98,7 +108,14 @@ async function generateTSFiles(conversionOptions: FilesConversionOptions) {
 
   if (exportCompleteIconSet) {
     await callAndMonitorAsync<void>(
-      generateCompleteIconSet.bind({}, svgDefinitions, outputDirectory, iconsFolderName, completeIconSetName),
+      generateCompleteIconSet.bind(
+        {},
+        svgDefinitions,
+        outputDirectory,
+        iconsFolderName,
+        completeIconSetName,
+        generateType && interfaceName
+      ),
       'Export complete icon set'
     );
     generatedFileNames.push(completeIconSetName);
@@ -182,9 +199,16 @@ const generateCompleteIconSet = async (
   svgDefinitions: SvgDefinition[],
   outputDirectory: string,
   iconsFolderName: string,
-  completeIconSetName: string
+  completeIconSetName: string,
+  interfaceName?: string,
+  modelFileName?: string
 ): Promise<void> => {
-  const completeIconSetContent = generateCompleteIconSetContent(svgDefinitions, completeIconSetName);
+  const completeIconSetContent = generateCompleteIconSetContent(
+    svgDefinitions,
+    completeIconSetName,
+    interfaceName,
+    modelFileName
+  );
   await writeFile(`${outputDirectory}/${iconsFolderName}`, completeIconSetName, completeIconSetContent);
 };
 

--- a/src/lib/converters/files.converter.ts
+++ b/src/lib/converters/files.converter.ts
@@ -38,7 +38,8 @@ async function generateTSXFiles(conversionOptions: FilesConversionOptions) {
     completeIconSetName,
     barrelFileName,
     interfaceName,
-    generateType
+    generateType,
+    modelFileName
   } = conversionOptions;
 
   const svgDefinitions = await callAndMonitorAsync<SvgDefinition[]>(
@@ -59,7 +60,8 @@ async function generateTSXFiles(conversionOptions: FilesConversionOptions) {
         outputDirectory,
         iconsFolderName,
         completeIconSetName,
-        generateType && interfaceName
+        generateType && interfaceName,
+        modelFileName
       ),
       'Export complete icon set'
     );
@@ -114,7 +116,8 @@ async function generateTSFiles(conversionOptions: FilesConversionOptions) {
         outputDirectory,
         iconsFolderName,
         completeIconSetName,
-        generateType && interfaceName
+        generateType && interfaceName,
+        modelFileName
       ),
       'Export complete icon set'
     );
@@ -201,13 +204,15 @@ const generateCompleteIconSet = async (
   iconsFolderName: string,
   completeIconSetName: string,
   interfaceName?: string,
-  modelFileName?: string
+  modelFileName?: string,
+  generateType?: boolean
 ): Promise<void> => {
   const completeIconSetContent = generateCompleteIconSetContent(
     svgDefinitions,
     completeIconSetName,
     interfaceName,
-    modelFileName
+    modelFileName,
+    generateType
   );
   await writeFile(`${outputDirectory}/${iconsFolderName}`, completeIconSetName, completeIconSetContent);
 };

--- a/src/lib/converters/files.converter.ts
+++ b/src/lib/converters/files.converter.ts
@@ -60,7 +60,8 @@ async function generateTSXFiles(conversionOptions: FilesConversionOptions) {
         outputDirectory,
         iconsFolderName,
         completeIconSetName,
-        generateType && interfaceName,
+        interfaceName,
+        generateType,
         modelFileName
       ),
       'Export complete icon set'
@@ -116,8 +117,9 @@ async function generateTSFiles(conversionOptions: FilesConversionOptions) {
         outputDirectory,
         iconsFolderName,
         completeIconSetName,
-        generateType && interfaceName,
-        modelFileName
+        interfaceName,
+        modelFileName,
+        generateType
       ),
       'Export complete icon set'
     );

--- a/src/lib/helpers/complete-icon-set-helper.spec.ts
+++ b/src/lib/helpers/complete-icon-set-helper.spec.ts
@@ -19,4 +19,27 @@ describe('Complete Iconset-helper', () => {
     const generatedContent = generateCompleteIconSetContent(fileNamesWithDefinitions, completeIconSetName);
     expect(unformatedString(expectedContent)).toEqual(unformatedString(generatedContent));
   });
+  it('should add interface when specified', () => {
+    let completeIconSetName = 'all-icons';
+    const fileNamesWithDefinitions = [
+      { variableName: 'foo', prefix: 'sampleIcon', filenameWithoutEnding: 'foo' },
+      { variableName: 'bar', prefix: 'sampleIcon', filenameWithoutEnding: 'bar' },
+      { variableName: 'baz', prefix: 'sampleIcon', filenameWithoutEnding: 'baz' }
+    ] as any;
+    const expectedContent = `
+    import {MyIcon} from './my-icons';
+    import {foo} from './sampleIcon-foo.icon';
+    import {bar} from './sampleIcon-bar.icon';
+    import {baz} from './sampleIcon-baz.icon';
+            
+    export const allIcons:MyIcon[] = [foo as MyIcon, bar as MyIcon, baz as MyIcon];`;
+
+    const generatedContent = generateCompleteIconSetContent(
+      fileNamesWithDefinitions,
+      completeIconSetName,
+      'MyIcon',
+      'my-icons'
+    );
+    expect(unformatedString(expectedContent)).toEqual(unformatedString(generatedContent));
+  });
 });

--- a/src/lib/helpers/complete-icon-set-helper.spec.ts
+++ b/src/lib/helpers/complete-icon-set-helper.spec.ts
@@ -38,7 +38,31 @@ describe('Complete Iconset-helper', () => {
       fileNamesWithDefinitions,
       completeIconSetName,
       'MyIcon',
-      'my-icons'
+      'my-icons',
+      true
+    );
+    expect(unformatedString(expectedContent)).toEqual(unformatedString(generatedContent));
+  });
+  it('should not add interface when generateType is false', () => {
+    let completeIconSetName = 'all-icons';
+    const fileNamesWithDefinitions = [
+      { variableName: 'foo', prefix: 'sampleIcon', filenameWithoutEnding: 'foo' },
+      { variableName: 'bar', prefix: 'sampleIcon', filenameWithoutEnding: 'bar' },
+      { variableName: 'baz', prefix: 'sampleIcon', filenameWithoutEnding: 'baz' }
+    ] as any;
+    const expectedContent = `
+    import {foo} from './sampleIcon-foo.icon';
+    import {bar} from './sampleIcon-bar.icon';
+    import {baz} from './sampleIcon-baz.icon';
+            
+    export const allIcons = [foo, bar, baz];`;
+
+    const generatedContent = generateCompleteIconSetContent(
+      fileNamesWithDefinitions,
+      completeIconSetName,
+      'MyIcon',
+      'my-icons',
+      false
     );
     expect(unformatedString(expectedContent)).toEqual(unformatedString(generatedContent));
   });

--- a/src/lib/helpers/complete-icon-set.helper.ts
+++ b/src/lib/helpers/complete-icon-set.helper.ts
@@ -8,10 +8,20 @@ export const generateCompleteIconSetContent = (
   svgDefinitions: SvgDefinition[],
   completeIconSetName: string,
   interfaceName?: string,
-  modelFileName?: string
+  modelFileName?: string,
+  generateType?: boolean
 ): string => {
-  const importSection = generateImportSection(svgDefinitions, interfaceName, modelFileName);
-  const exportSection = generateExportSection(svgDefinitions, completeIconSetName, FILE_TYPE.TS, interfaceName);
+  const importSection = generateImportSection(
+    svgDefinitions,
+    generateType ? interfaceName : undefined,
+    generateType ? modelFileName : undefined
+  );
+  const exportSection = generateExportSection(
+    svgDefinitions,
+    completeIconSetName,
+    FILE_TYPE.TS,
+    generateType ? interfaceName : undefined
+  );
   return `${importSection}${exportSection}`;
 };
 

--- a/src/lib/helpers/complete-icon-set.helper.ts
+++ b/src/lib/helpers/complete-icon-set.helper.ts
@@ -6,37 +6,51 @@ import { FILE_TYPE } from '../shared/file-type.model';
 
 export const generateCompleteIconSetContent = (
   svgDefinitions: SvgDefinition[],
-  completeIconSetName: string
+  completeIconSetName: string,
+  interfaceName?: string,
+  modelFileName?: string
 ): string => {
-  const importSection = generateImportSection(svgDefinitions);
-  const exportSection = generateExportSection(svgDefinitions, completeIconSetName);
+  const importSection = generateImportSection(svgDefinitions, interfaceName, modelFileName);
+  const exportSection = generateExportSection(svgDefinitions, completeIconSetName, FILE_TYPE.TS, interfaceName);
   return `${importSection}${exportSection}`;
 };
 
-const generateImportSection = (svgDefinitions: SvgDefinition[]): string =>
-  svgDefinitions.reduce((acc: string, svgDefinition: SvgDefinition) => {
+const generateImportSection = (
+  svgDefinitions: SvgDefinition[],
+  interfaceName?: string,
+  modelFileName?: string
+): string => {
+  const imports =
+    interfaceName && modelFileName ? generateNamedImportStatement(interfaceName, `./${modelFileName}`) : '';
+  return svgDefinitions.reduce((acc: string, svgDefinition: SvgDefinition) => {
     acc += generateNamedImportStatement(
       svgDefinition.variableName,
       `./${svgDefinition.prefix}-${svgDefinition.filenameWithoutEnding}.icon`
     );
     return acc;
-  }, '');
+  }, imports);
+};
 
 export const generateExportSection = (
   svgDefinitions: SvgDefinition[],
   completeIconSetName: string,
-  fileType = FILE_TYPE.TS
-): string =>
-  svgDefinitions.reduce((acc: string, svgDefinition: SvgDefinition, index: number) => {
+  fileType = FILE_TYPE.TS,
+  interfaceName?: string
+): string => {
+  const interfaceSuffix = interfaceName ? `:${interfaceName}[]` : '';
+  return svgDefinitions.reduce((acc: string, svgDefinition: SvgDefinition, index: number) => {
     const variableName =
       fileType === FILE_TYPE.TSX
         ? svgDefinition.variableName.charAt(0).toUpperCase() + svgDefinition.variableName.slice(1)
         : svgDefinition.variableName;
 
+    const interfaceSuffix = interfaceName ? ` as ${interfaceName}` : '';
+
     if (index === svgDefinitions.length - 1) {
-      acc += `${variableName}];`;
+      acc += `${variableName}${interfaceSuffix}];`;
     } else {
-      acc += `${variableName},`;
+      acc += `${variableName}${interfaceSuffix},`;
     }
     return acc;
-  }, `export const ${camelCase(completeIconSetName)} = [`);
+  }, `export const ${camelCase(completeIconSetName)}${interfaceSuffix} = [`);
+};


### PR DESCRIPTION
When generating a complete icon set with a large number of icons.

Typescript build fails with error: `"Expression produces a union type that is too complex to represent"`

This is because it is trying to infer a type from all the icon constants i.e. for:

```
export const fooIcon: {
  name: 'foo-icon';
  data: string;
} = {
  name: 'foo-icon',
  data: `....`
};

export const barIcon: {
  name: 'bar-icon';
  data: string;
} = {
  name: 'bar-icon',
  data: `....`
};
```

It has to calculate the interface:

```
interface Inferred {
   name: 'foo-icon'|'bar-icon',
   data:string
}
```

When we have already calculated it we can avoid the issue by specifying the types ourselves