### PR TITLE
feat: adds-pops-to-tsx-const-svg-components

### DIFF
--- a/src/lib/generators/code-snippet-generators.ts
+++ b/src/lib/generators/code-snippet-generators.ts
@@ -111,7 +111,8 @@ export const generateSvgConstant = (variableName: string, filenameWithoutEnding:
 
 export function generateTSXConstant(variableName: string, svg: string) {
   const variableNameCapitalized = variableName.charAt(0).toUpperCase() + variableName.slice(1);
-  return `export const ${variableNameCapitalized} = () => (${svg});`;
+  const svgStringWithProps = svg.replace('>', ' {...props}>');
+  return `export const ${variableNameCapitalized} = (props) => (${svgStringWithProps});`;
 }
 
 export const generateExportStatement = (fileName: string, generatedIconsFolderName?: string): string => {


### PR DESCRIPTION
Idea of this suggested improvement is to provide ability for tsx cost icon components to get props that are passed from React app, down to component, like className or any other possible prop.

Desired output should look like this: 
`/* 🤖 this file was generated by svg-to-ts */
export const RtestIcon = (props) => (<svg viewBox="0 0 24 24" fill="none" {...props}>
  <g clip-path="url(#clip0_666_11336)">
    <path fill-rule="evenodd" clip-rule="evenodd" d="M1564te5465445" fill="currentColor"/>
  </g>
</svg>
);`