### PR TITLE
fix(esm): deliver correct esm files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ora": "^5.1.0",
         "prettier": "^1.19.1",
         "svgo": "^2.7.0",
-        "typescript": "^3.7.2"
+        "typescript": "^4.9.4"
       },
       "bin": {
         "svg-to-ts-constants": "src/bin/svg-to-ts-constants.js",
@@ -6743,6 +6743,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-conductor/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/import-fresh": {
@@ -19355,9 +19368,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25441,6 +25454,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
         }
       }
     },
@@ -35226,9 +35245,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ora": "^5.1.0",
     "prettier": "^1.19.1",
     "svgo": "^2.7.0",
-    "typescript": "^3.7.2"
+    "typescript": "^4.9.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/src/lib/compiler/typescript-compiler.ts
+++ b/src/lib/compiler/typescript-compiler.ts
@@ -1,3 +1,4 @@
+import { lstatSync, readdirSync, renameSync } from 'fs';
 import * as ts from 'typescript';
 
 export const compileToEsNext = (filePaths: string[], outputDir: string): void => {
@@ -11,6 +12,26 @@ export const compileToEsNext = (filePaths: string[], outputDir: string): void =>
   };
 
   ts.createProgram(filePaths, compilerOptionsNext).emit();
+  renameJsFilesToMJs(outputDir);
+};
+
+export const renameJsFilesToMJs = (outputDir: string) => {
+  const children = readdirSync(outputDir);
+
+  if (children.length === 0) {
+    return;
+  }
+
+  children.forEach(file => {
+    const path = `${outputDir}/${file}`;
+    if (lstatSync(path).isDirectory()) {
+      renameJsFilesToMJs(path);
+    } else {
+      if (file.endsWith('.js')) {
+        renameSync(path, path.replace('.js', '.mjs'));
+      }
+    }
+  });
 };
 
 export const compileToUMD = (filePaths: string[], outputDir: string): void => {


### PR DESCRIPTION
BREAKING CHANGE: Previously esm files were delivered with a .js ending. Now they will be delivered with a .mjs ending

#201