### PR TITLE
Added delimiter NONE - existing delimiter changed filenames when including numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,19 +242,19 @@ accepts an object with the filename as key and the svg data as key.
 
 #### Available options:
 
-| --version       | type                       | default                                  | description                                                                                  |
-| --------------- | -------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------- |
-| fileName        | string                     | my-icons                                 | file name of the generated file                                                              |
-| tsx             | boolean                    | false                                    | Generate TSX file which can be used as React components out of the box                       |
-| delimiter       | CAMEL, KEBAB, SNAKE, UPPER | CAMEL                                    | delimiter which is used to generate the types and name properties                            |
-| svgoConfig      | null or config object      | check help command - to large to display | by default we search for a svgo.config.js file in the root or an inline configuration object |
-| srcFiles        | string                     | "/\*.svg"                                | input files matching the given filename pattern                                              |
-| outputDirectory | string                     | "./dist"                                 | name of the output directory                                                                 |
-| objectName      | string                     | default - export                         | name of the exported const - if nothing is set - default export will be used                 |
-| verbose         | boolean                    | false                                    | defines if the log should contain additional information. Can be useful for debugging        |
-| generateType    | boolean                    | true                                     | defines if a type should be generated                                                        |
-| typeName        | string                     | MyIconType                               | name of the type to be used when `generateType` is set to `true`                             |
-| namePrefix      | string                     |                                          | prefix to be used for the name property included in the generated constant                   |
+| --version       | type                             | default                                  | description                                                                                  |
+| --------------- |----------------------------------| ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| fileName        | string                           | my-icons                                 | file name of the generated file                                                              |
+| tsx             | boolean                          | false                                    | Generate TSX file which can be used as React components out of the box                       |
+| delimiter       | CAMEL, KEBAB, SNAKE, UPPER, NONE | CAMEL                                    | delimiter which is used to generate the types and name properties                            |
+| svgoConfig      | null or config object            | check help command - to large to display | by default we search for a svgo.config.js file in the root or an inline configuration object |
+| srcFiles        | string                           | "/\*.svg"                                | input files matching the given filename pattern                                              |
+| outputDirectory | string                           | "./dist"                                 | name of the output directory                                                                 |
+| objectName      | string                           | default - export                         | name of the exported const - if nothing is set - default export will be used                 |
+| verbose         | boolean                          | false                                    | defines if the log should contain additional information. Can be useful for debugging        |
+| generateType    | boolean                          | true                                     | defines if a type should be generated                                                        |
+| typeName        | string                           | MyIconType                               | name of the type to be used when `generateType` is set to `true`                             |
+| namePrefix      | string                           |                                          | prefix to be used for the name property included in the generated constant                   |
 
 #### Example usage
 
@@ -305,7 +305,7 @@ Only the icons included in the consuming SPA also end up in the final bundle of 
 | interfaceName         | string                     | MyIcon                                   | name for the generated interface                                                      |
 | fileName              | string                     | my-icons                                 | file name of the generated file                                                       |
 | enumName              | string                     | MyIcons                                  | name for the generated enum                                                           |
-| delimiter             | CAMEL, KEBAB, SNAKE, UPPER | SNAKE                                    | delimiter which is used to generate the types and name properties                     |
+| delimiter             | CAMEL, KEBAB, SNAKE, UPPER, NONE | SNAKE                                    | delimiter which is used to generate the types and name properties                     |
 | svgoConfig            | string or config object    | check help command - to large to display | a path to your svgoConfiguration JSON file or an inline configuration object          |
 | srcFiles              | string                     | "/\*.svg"                                | input files matching the given filename pattern                                       |
 | outputDirectory       | string                     | "./dist"                                 | name of the output directory                                                          |
@@ -400,7 +400,7 @@ end up there.
 | interfaceName             | string                     | MyIcon                                   | name for the generated interface                                                                                                                                                |
 | modelFileName             | string                     | my-icons                                 | file name of the generated file                                                                                                                                                 |
 | enumName                  | string                     | MyIcons                                  | name for the generated enum                                                                                                                                                     |
-| delimiter                 | CAMEL, KEBAB, SNAKE, UPPER | SNAKE                                    | delimiter which is used to generate the types and name properties                                                                                                               |
+| delimiter                 | CAMEL, KEBAB, SNAKE, UPPER, NONE | SNAKE                                    | delimiter which is used to generate the types and name properties                                                                                                               |
 | srcFiles                  | string                     | "/\*.svg"                                | input files matching the given filename pattern                                                                                                                                 |
 | svgoConfig                | null or config object      | check help command - to large to display | by default we search for a svgo.config.js file in the root or an inline configuration object                                                                                    |
 | outputDirectory           | string                     | "./dist"                                 | name of the output directory                                                                                                                                                    |

--- a/src/lib/generators/code-snippet-generators.spec.ts
+++ b/src/lib/generators/code-snippet-generators.spec.ts
@@ -139,55 +139,55 @@ describe('Generators', () => {
 
   describe('generateTypeName', () => {
     it('should return the correct type name with delimiter SNAKE', () => {
-      const fileName = 'a12-a12-chevron-top';
-      expect(generateTypeName(fileName, Delimiter.SNAKE)).toEqual('a_12_a_12chevron_top');
+      const fileName = 'a12-chevron-top-22';
+      expect(generateTypeName(fileName, Delimiter.SNAKE)).toEqual('a_12_chevron_top_22');
     });
 
     it('should return the correct type name with delimiter CAMEL', () => {
-      const fileName = 'a3-a3-chevron-top';
-      expect(generateTypeName(fileName, Delimiter.CAMEL)).toEqual('a3A3ChevronTop');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.CAMEL)).toEqual('a12ChevronTop22');
     });
 
     it('should return the correct type name with delimiter KEBAB', () => {
-      const fileName = 'a12-a12-chevron_top';
-      expect(generateTypeName(fileName, Delimiter.KEBAB)).toEqual('a-12-a-12-chevron-top');
+      const fileName = 'a12_chevron_top22';
+      expect(generateTypeName(fileName, Delimiter.KEBAB)).toEqual('a-12-chevron-top-22');
     });
 
     it('should return the correct type name with delimiter UPPER', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.UPPER)).toEqual('CHEVRON_TOP');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.UPPER)).toEqual('A_12_CHEVRON_TOP_22');
     });
 
     it('should return the initial type name delimiter NONE', () => {
-      const fileName = 'a12-a12-a3-chevron-top123';
-      expect(generateTypeName(fileName, Delimiter.NONE)).toEqual('a12-a12-a3-chevron-top123');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.NONE)).toEqual('a12-chevron-top22');
     });
   });
 
   describe('generateTypeName with prefix', () => {
     it('should return the correct type name with delimiter SNAKE', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.SNAKE, 'example-')).toEqual('example-chevron_top');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.SNAKE, 'example-')).toEqual('example-a_12_chevron_top_22');
     });
 
     it('should return the correct type name with delimiter CAMEL', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.CAMEL, 'example-')).toEqual('example-chevronTop');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.CAMEL, 'example-')).toEqual('example-a12ChevronTop22');
     });
 
     it('should return the correct type name with delimiter KEBAB', () => {
-      const fileName = 'chevron_top';
-      expect(generateTypeName(fileName, Delimiter.KEBAB, 'example-')).toEqual('example-chevron-top');
+      const fileName = 'a12-chevron_top22';
+      expect(generateTypeName(fileName, Delimiter.KEBAB, 'example-')).toEqual('example-a-12-chevron-top-22');
     });
 
     it('should return the correct type name with delimiter UPPER', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.UPPER, 'example-')).toEqual('example-CHEVRON_TOP');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.UPPER, 'example-')).toEqual('example-A_12_CHEVRON_TOP_22');
     });
 
     it('should return the correct type name with delimiter NONE', () => {
-      const fileName = 'a3-chevron-top';
-      expect(generateTypeName(fileName, Delimiter.NONE, 'example-')).toEqual('example-a3-chevron-top');
+      const fileName = 'a12-chevron-top22';
+      expect(generateTypeName(fileName, Delimiter.NONE, 'example-')).toEqual('example-a12-chevron-top22');
     });
   });
 

--- a/src/lib/generators/code-snippet-generators.spec.ts
+++ b/src/lib/generators/code-snippet-generators.spec.ts
@@ -139,23 +139,28 @@ describe('Generators', () => {
 
   describe('generateTypeName', () => {
     it('should return the correct type name with delimiter SNAKE', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.SNAKE)).toEqual('chevron_top');
+      const fileName = 'a12-a12-chevron-top';
+      expect(generateTypeName(fileName, Delimiter.SNAKE)).toEqual('a_12_a_12chevron_top');
     });
 
     it('should return the correct type name with delimiter CAMEL', () => {
-      const fileName = 'chevron-top';
-      expect(generateTypeName(fileName, Delimiter.CAMEL)).toEqual('chevronTop');
+      const fileName = 'a3-a3-chevron-top';
+      expect(generateTypeName(fileName, Delimiter.CAMEL)).toEqual('a3A3ChevronTop');
     });
 
     it('should return the correct type name with delimiter KEBAB', () => {
-      const fileName = 'chevron_top';
-      expect(generateTypeName(fileName, Delimiter.KEBAB)).toEqual('chevron-top');
+      const fileName = 'a12-a12-chevron_top';
+      expect(generateTypeName(fileName, Delimiter.KEBAB)).toEqual('a-12-a-12-chevron-top');
     });
 
     it('should return the correct type name with delimiter UPPER', () => {
       const fileName = 'chevron-top';
       expect(generateTypeName(fileName, Delimiter.UPPER)).toEqual('CHEVRON_TOP');
+    });
+
+    it('should return the initial type name delimiter NONE', () => {
+      const fileName = 'a12-a12-a3-chevron-top123';
+      expect(generateTypeName(fileName, Delimiter.NONE)).toEqual('a12-a12-a3-chevron-top123');
     });
   });
 
@@ -178,6 +183,11 @@ describe('Generators', () => {
     it('should return the correct type name with delimiter UPPER', () => {
       const fileName = 'chevron-top';
       expect(generateTypeName(fileName, Delimiter.UPPER, 'example-')).toEqual('example-CHEVRON_TOP');
+    });
+
+    it('should return the correct type name with delimiter NONE', () => {
+      const fileName = 'a3-chevron-top';
+      expect(generateTypeName(fileName, Delimiter.NONE, 'example-')).toEqual('example-a3-chevron-top');
     });
   });
 

--- a/src/lib/generators/code-snippet-generators.ts
+++ b/src/lib/generators/code-snippet-generators.ts
@@ -11,7 +11,8 @@ export enum Delimiter {
   CAMEL = 'CAMEL',
   KEBAB = 'KEBAB',
   SNAKE = 'SNAKE',
-  UPPER = 'UPPER'
+  UPPER = 'UPPER',
+  NONE = 'NONE'
 }
 
 export const generateInterfaceDefinition = (conversionOptions: FilesConversionOptions | ConstantsConversionOptions) => {
@@ -134,6 +135,9 @@ export const generateTypeName = (filenameWithoutEnding, delimiter: Delimiter, na
   }
   if (delimiter === Delimiter.UPPER) {
     return `${namePrefix || ''}${snakeCase(filenameWithoutEnding).toUpperCase()}`;
+  }
+  if (delimiter === Delimiter.NONE) {
+    return `${namePrefix || ''}${filenameWithoutEnding}`;
   }
   return `${namePrefix || ''}${snakeCase(filenameWithoutEnding)}`;
 };


### PR DESCRIPTION
Hi there, 

first of all: Thank you for your guide (https://kevinkreuzer.medium.com/how-to-build-your-own-tree-shakable-svg-icons-library-in-less-than-30-minutes-9f7a4a324d29) and the packages you created to make such an implementation straight forward.

Within this PR i implemented the new delimiter 'NONE', which just return the filename without changing it. All the existing delimiters would have changed the filename and that would have caused a lot of work for the company.

While following your guide, i was running into the issue, that the generated icon names of icons including numbers got changed like the example below: (using SNAKE delimiter)
`g3-dropdown changed into ==> g_3_dropdown`

As the filename is currently used to render the icon inside our applications, i would like to keep them to avoid extra work.

BR, Malte

P.S. i wasn't able to clone the repo locally, so i downloaded the ZIP, did the changes locally and copied them into the github editor. Thats why i couldn't follow along the "Commit Convention" - sorry for that.
