### PR TITLE
feat(esm): use .mjs ext in import / export statements of compiled files

### DIFF
--- a/src/lib/compiler/typescript-compiler.ts
+++ b/src/lib/compiler/typescript-compiler.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readdirSync, renameSync } from 'fs';
+import { lstatSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import * as ts from 'typescript';
 
 export const compileToEsNext = (filePaths: string[], outputDir: string): void => {
@@ -7,12 +7,36 @@ export const compileToEsNext = (filePaths: string[], outputDir: string): void =>
     declaration: true,
     outDir: outputDir,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    target: ts.ScriptTarget.ES5,
+    target: ts.ScriptTarget.ES2020,
     module: ts.ModuleKind.ESNext
   };
 
   ts.createProgram(filePaths, compilerOptionsNext).emit();
   renameJsFilesToMJs(outputDir);
+  addMJsExtensionToImportStatements(outputDir);
+};
+
+export const addMJsExtensionToImportStatements = (outputDir: string): void => {
+  const children = readdirSync(outputDir);
+
+  if (children.length === 0) {
+    return;
+  }
+
+  children.forEach(file => {
+    const path = `${outputDir}/${file}`;
+    if (lstatSync(path).isDirectory()) {
+      addMJsExtensionToImportStatements(path);
+    } else {
+      if (path.endsWith('.mjs')) {
+        const content = readFileSync(path, 'utf8');
+        if (content) {
+          const contentWithExtensions = content.replace(/';/g, ".mjs';");
+          writeFileSync(path, contentWithExtensions, 'utf8');
+        }
+      }
+    }
+  });
 };
 
 export const renameJsFilesToMJs = (outputDir: string) => {
@@ -39,7 +63,7 @@ export const compileToUMD = (filePaths: string[], outputDir: string): void => {
     declaration: true,
     outDir: outputDir,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    target: ts.ScriptTarget.ES2016,
+    target: ts.ScriptTarget.ES2020,
     module: ts.ModuleKind.UMD
   };
   ts.createProgram(filePaths, compilerOptionsUMD).emit();


### PR DESCRIPTION
BREAKING CHANGE: add .mjs extenstion in import / export statements

- support for esbuild